### PR TITLE
add missing References for Example

### DIFF
--- a/examplePlugin/examplePlugin.vcxproj
+++ b/examplePlugin/examplePlugin.vcxproj
@@ -136,6 +136,9 @@
     <ProjectReference Include="..\..\..\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj">
       <Project>{5837595d-aca9-485c-8e76-729040ce4b0b}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\ofxSingleton\ofxSingletonLib\ofxSingleton.vcxproj">
+      <Project>{4d3bcfdd-e65d-4247-b303-e0839caec6a6}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ofxPluginLib/ofxPluginLib.vcxproj
+++ b/ofxPluginLib/ofxPluginLib.vcxproj
@@ -140,6 +140,11 @@
   <ItemGroup>
     <ClCompile Include="..\src\ofxPlugin\FactoryRegister.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\ofxSingleton\ofxSingletonLib\ofxSingleton.vcxproj">
+      <Project>{4d3bcfdd-e65d-4247-b303-e0839caec6a6}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
examplePlugin and ofxPluginLib need Visual Studio Project
References to the ofxSingleton Project.

Without these, the linker would not be able to link the
visual studio project files for ofxPluginLib.

Closes issue #1.
